### PR TITLE
Issue 2 - Add initial support for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # txt2html
 
-Static Site Generator that converts .txt to .html
+Static Site Generator that converts .txt and .md to .html
 
 ## Features
 
 -   Support for custom stylesheets
 -   Custom output directory
+-   Support converting .md to .html
 
 ## Installation
 

--- a/dist/README.html
+++ b/dist/README.html
@@ -8,7 +8,7 @@
   
 </head>
 <body>
-<p><h1 id="txt2html">txt2html</h1>
+<h1 id="txt2html">txt2html</h1>
 <p>Static Site Generator that converts .txt to .html</p>
 <h2 id="features">Features</h2>
 <ul>
@@ -23,8 +23,9 @@
 </ol>
 <h2 id="example">Example</h2>
 <p>Running <code>npm start -- -i hello.txt</code> containing</p>
-<pre><code>Hello world!</p>
-<p>This world is beautiful
+<pre><code>Hello world!
+
+This world is beautiful
 </code></pre>
 <p>will generate output file <code>dist/hello.html</code> containing</p>
 <pre><code>&lt;!doctype html&gt;
@@ -32,8 +33,9 @@
 &lt;head&gt;
   &lt;meta charset=&quot;utf-8&quot;&gt;
   &lt;title&gt;hello&lt;/title&gt;
-  &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;&gt;</p>
-<p>&lt;/head&gt;
+  &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;&gt;
+
+&lt;/head&gt;
 &lt;body&gt;
 &lt;p&gt;Hello world!&lt;/p&gt;
 &lt;p&gt;This world is beautiful&lt;/p&gt;
@@ -41,13 +43,15 @@
 &lt;/html&gt;
 </code></pre>
 <h2 id="usage">Usage</h2>
-<pre><code>Usage: txt2html.js [options]</p>
-<p>Options:
+<pre><code>Usage: txt2html.js [options]
+
+Options:
   -h, --help        Show help message                                  [boolean]
   -v, --version     Show current version                               [boolean]
   -i, --input       Input txt file / directory with txt files         [required]
   -o, --output      Path to folder with generated files        [default: &quot;dist&quot;]
   -s, --stylesheet  Adds custom CSS to generated html
-</code></pre></p>
+</code></pre>
+
 </body>
 </html>

--- a/dist/README.html
+++ b/dist/README.html
@@ -1,0 +1,53 @@
+
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>README</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  
+</head>
+<body>
+<p><h1 id="txt2html">txt2html</h1>
+<p>Static Site Generator that converts .txt to .html</p>
+<h2 id="features">Features</h2>
+<ul>
+<li>Support for custom stylesheets</li>
+<li>Custom output directory</li>
+</ul>
+<h2 id="installation">Installation</h2>
+<p>To run this script you need to:</p>
+<ol>
+<li><code>git clone https://github.com/tcvan0707/txt2html.git &amp;&amp; cd txt2html</code></li>
+<li><code>npm install</code></li>
+</ol>
+<h2 id="example">Example</h2>
+<p>Running <code>npm start -- -i hello.txt</code> containing</p>
+<pre><code>Hello world!</p>
+<p>This world is beautiful
+</code></pre>
+<p>will generate output file <code>dist/hello.html</code> containing</p>
+<pre><code>&lt;!doctype html&gt;
+&lt;html lang=&quot;en&quot;&gt;
+&lt;head&gt;
+  &lt;meta charset=&quot;utf-8&quot;&gt;
+  &lt;title&gt;hello&lt;/title&gt;
+  &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;&gt;</p>
+<p>&lt;/head&gt;
+&lt;body&gt;
+&lt;p&gt;Hello world!&lt;/p&gt;
+&lt;p&gt;This world is beautiful&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+<h2 id="usage">Usage</h2>
+<pre><code>Usage: txt2html.js [options]</p>
+<p>Options:
+  -h, --help        Show help message                                  [boolean]
+  -v, --version     Show current version                               [boolean]
+  -i, --input       Input txt file / directory with txt files         [required]
+  -o, --output      Path to folder with generated files        [default: &quot;dist&quot;]
+  -s, --stylesheet  Adds custom CSS to generated html
+</code></pre></p>
+</body>
+</html>

--- a/dist/README.html
+++ b/dist/README.html
@@ -8,50 +8,62 @@
   
 </head>
 <body>
-<h1 id="txt2html">txt2html</h1>
-<p>Static Site Generator that converts .txt to .html</p>
-<h2 id="features">Features</h2>
-<ul>
-<li>Support for custom stylesheets</li>
-<li>Custom output directory</li>
-</ul>
-<h2 id="installation">Installation</h2>
-<p>To run this script you need to:</p>
-<ol>
-<li><code>git clone https://github.com/tcvan0707/txt2html.git &amp;&amp; cd txt2html</code></li>
-<li><code>npm install</code></li>
-</ol>
-<h2 id="example">Example</h2>
-<p>Running <code>npm start -- -i hello.txt</code> containing</p>
-<pre><code>Hello world!
+<h1>txt2html</h1>
+
+Static Site Generator that converts .txt to .html
+
+## Features
+
+-   Support for custom stylesheets
+-   Custom output directory
+
+## Installation
+
+To run this script you need to:
+
+1. `git clone https://github.com/tcvan0707/txt2html.git && cd txt2html`
+2. `npm install`
+
+## Example
+
+Running `npm start -- -i hello.txt` containing
+
+```
+Hello world!
 
 This world is beautiful
-</code></pre>
-<p>will generate output file <code>dist/hello.html</code> containing</p>
-<pre><code>&lt;!doctype html&gt;
-&lt;html lang=&quot;en&quot;&gt;
-&lt;head&gt;
-  &lt;meta charset=&quot;utf-8&quot;&gt;
-  &lt;title&gt;hello&lt;/title&gt;
-  &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;&gt;
+```
 
-&lt;/head&gt;
-&lt;body&gt;
-&lt;p&gt;Hello world!&lt;/p&gt;
-&lt;p&gt;This world is beautiful&lt;/p&gt;
-&lt;/body&gt;
-&lt;/html&gt;
-</code></pre>
-<h2 id="usage">Usage</h2>
-<pre><code>Usage: txt2html.js [options]
+will generate output file `dist/hello.html` containing
+
+```
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>hello</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+</head>
+<body>
+<p>Hello world!</p>
+<p>This world is beautiful</p>
+</body>
+</html>
+```
+
+## Usage
+
+```
+Usage: txt2html.js [options]
 
 Options:
   -h, --help        Show help message                                  [boolean]
   -v, --version     Show current version                               [boolean]
   -i, --input       Input txt file / directory with txt files         [required]
-  -o, --output      Path to folder with generated files        [default: &quot;dist&quot;]
+  -o, --output      Path to folder with generated files        [default: "dist"]
   -s, --stylesheet  Adds custom CSS to generated html
-</code></pre>
+```
 
 </body>
 </html>

--- a/dist/README.html
+++ b/dist/README.html
@@ -8,62 +8,50 @@
   
 </head>
 <body>
-<h1>txt2html</h1>
-
-Static Site Generator that converts .txt to .html
-
-## Features
-
--   Support for custom stylesheets
--   Custom output directory
-
-## Installation
-
-To run this script you need to:
-
-1. `git clone https://github.com/tcvan0707/txt2html.git && cd txt2html`
-2. `npm install`
-
-## Example
-
-Running `npm start -- -i hello.txt` containing
-
-```
-Hello world!
+<h1 id="txt2html">txt2html</h1>
+<p>Static Site Generator that converts .txt to .html</p>
+<h2 id="features">Features</h2>
+<ul>
+<li>Support for custom stylesheets</li>
+<li>Custom output directory</li>
+</ul>
+<h2 id="installation">Installation</h2>
+<p>To run this script you need to:</p>
+<ol>
+<li><code>git clone https://github.com/tcvan0707/txt2html.git &amp;&amp; cd txt2html</code></li>
+<li><code>npm install</code></li>
+</ol>
+<h2 id="example">Example</h2>
+<p>Running <code>npm start -- -i hello.txt</code> containing</p>
+<pre><code>Hello world!
 
 This world is beautiful
-```
+</code></pre>
+<p>will generate output file <code>dist/hello.html</code> containing</p>
+<pre><code>&lt;!doctype html&gt;
+&lt;html lang=&quot;en&quot;&gt;
+&lt;head&gt;
+  &lt;meta charset=&quot;utf-8&quot;&gt;
+  &lt;title&gt;hello&lt;/title&gt;
+  &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot;&gt;
 
-will generate output file `dist/hello.html` containing
-
-```
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>hello</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-
-</head>
-<body>
-<p>Hello world!</p>
-<p>This world is beautiful</p>
-</body>
-</html>
-```
-
-## Usage
-
-```
-Usage: txt2html.js [options]
+&lt;/head&gt;
+&lt;body&gt;
+&lt;p&gt;Hello world!&lt;/p&gt;
+&lt;p&gt;This world is beautiful&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+<h2 id="usage">Usage</h2>
+<pre><code>Usage: txt2html.js [options]
 
 Options:
   -h, --help        Show help message                                  [boolean]
   -v, --version     Show current version                               [boolean]
   -i, --input       Input txt file / directory with txt files         [required]
-  -o, --output      Path to folder with generated files        [default: "dist"]
+  -o, --output      Path to folder with generated files        [default: &quot;dist&quot;]
   -s, --stylesheet  Adds custom CSS to generated html
-```
+</code></pre>
 
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -525,6 +525,11 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
+    "fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha1-invTcYa23d84E/I4WLV+yq9eQdQ="
+    },
     "fs.promises": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/fs.promises/-/fs.promises-0.1.2.tgz",
@@ -734,6 +739,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-Oz2AIg5iUGjllkWLUk0OeF8fuIqoSVKwBv1RPzq1crlEPF/eg0u+sgBOrkfkSbhM/7JDUb6xatN8jVaUpSGVnA==",
+      "requires": {
+        "node-bin-setup": "^1.0.0"
+      }
+    },
+    "node-bin-setup": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
+      "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
     },
     "once": {
       "version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -525,6 +525,11 @@
       "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
       "dev": true
     },
+    "fs.promises": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fs.promises/-/fs.promises-0.1.2.tgz",
+      "integrity": "sha512-LNfkXdN6EToumV455EbdJaNxqLmEFqKqNZVIEyI2whtdpIppTsne2fHWgx05s+B2Aif29Lhzdz0AaOXKLvMGsA=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,6 +113,11 @@
       "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -719,6 +724,19 @@
         "yallist": "^4.0.0"
       }
     },
+    "markdown": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/markdown/-/markdown-0.5.0.tgz",
+      "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI=",
+      "requires": {
+        "nopt": "~2.1.1"
+      }
+    },
+    "marked": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.4.tgz",
+      "integrity": "sha512-jBo8AOayNaEcvBhNobg6/BLhdsK3NvnKWJg33MAAPbvTWiG4QBn9gpW1+7RssrKu4K1dKlN+0goVQwV41xEfOA=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -752,6 +770,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
       "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
+    },
+    "nopt": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+      "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
+      "requires": {
+        "abbrev": "1"
+      }
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/tcvan0707/txt2html#readme",
   "dependencies": {
+    "fs.promises": "^0.1.2",
     "yargs": "^17.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "homepage": "https://github.com/tcvan0707/txt2html#readme",
   "dependencies": {
+    "fs": "0.0.1-security",
     "fs.promises": "^0.1.2",
+    "node": "^16.9.1",
     "yargs": "^17.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "dependencies": {
     "fs": "0.0.1-security",
     "fs.promises": "^0.1.2",
+    "markdown": "^0.5.0",
+    "marked": "^3.0.4",
     "node": "^16.9.1",
     "yargs": "^17.1.1"
   },

--- a/src/generator.js
+++ b/src/generator.js
@@ -3,7 +3,12 @@ export function generateFromText(text, filename, cssHref) {
     return insertInTemplate(tags, filename, cssHref);
 }
 
-export function insertInTemplate(tags, filename, cssHref) {
+export function generateFromMd(text, filename, cssHref){
+    let tags = boldText(text);
+    return insertInTemplate(tags, filename, cssHref);
+}
+
+function insertInTemplate(tags, filename, cssHref) {
     return `
 <!doctype html>
 <html lang="en">
@@ -28,3 +33,8 @@ function splitInParagraphs(text) {
         .map((paragraph) => `<p>${paragraph}</p>`)
         .join("\n");
 }
+
+function boldText(text){
+    return text.replace(/^# (.*$)/gim, '<h1>$1</h1>');
+}
+

--- a/src/generator.js
+++ b/src/generator.js
@@ -3,7 +3,7 @@ export function generateFromText(text, filename, cssHref) {
     return insertInTemplate(tags, filename, cssHref);
 }
 
-function insertInTemplate(tags, filename, cssHref) {
+export function insertInTemplate(tags, filename, cssHref) {
     return `
 <!doctype html>
 <html lang="en">

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,9 +1,11 @@
+import marked from "marked";
 export function generateFromText(text, filename, cssHref) {
     let tags = splitInParagraphs(text);
     return insertInTemplate(tags, filename, cssHref);
 }
 
 export function generateFromMd(text, filename, cssHref){
+    text = marked(text);
     let tags = boldText(text);
     return insertInTemplate(tags, filename, cssHref);
 }

--- a/src/txt2html.js
+++ b/src/txt2html.js
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
 import marked from "marked";
-import {generateFromText} from "./generator.js";
+import {generateFromText, insertInTemplate} from "./generator.js";
 
 const argv = yargs(process.argv.slice(2))
     .usage("Usage: $0 [options]")
@@ -43,7 +43,7 @@ async function txt2html(filePath) {
             const text = (await fs.readFile(filePath)).toString();
             const fileName = path.basename(filePath, path.extname(filePath));
             const htmlPath = path.join(argv.output, fileName + ".html");
-            const html = generateFromText(marked(text), fileName, argv.stylesheet);
+            const html = insertInTemplate(marked(text), fileName, argv.stylesheet);
             await fs.writeFile(htmlPath, html);
         }else{
             throw new Error("Incorrect path");

--- a/src/txt2html.js
+++ b/src/txt2html.js
@@ -43,7 +43,7 @@ async function txt2html(filePath) {
             const text = (await fs.readFile(filePath)).toString();
             const fileName = path.basename(filePath, path.extname(filePath));
             const htmlPath = path.join(argv.output, fileName + ".html");
-            const html = generateFromMd(text, fileName, argv.stylesheet);
+            const html = generateFromMd(mark(text), fileName, argv.stylesheet);
             await fs.writeFile(htmlPath, html);
         }else{
             throw new Error("Incorrect path");

--- a/src/txt2html.js
+++ b/src/txt2html.js
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
 import marked from "marked";
-import {generateFromText, insertInTemplate} from "./generator.js";
+import {generateFromText, generateFromMd} from "./generator.js";
 
 const argv = yargs(process.argv.slice(2))
     .usage("Usage: $0 [options]")
@@ -43,7 +43,7 @@ async function txt2html(filePath) {
             const text = (await fs.readFile(filePath)).toString();
             const fileName = path.basename(filePath, path.extname(filePath));
             const htmlPath = path.join(argv.output, fileName + ".html");
-            const html = insertInTemplate(marked(text), fileName, argv.stylesheet);
+            const html = generateFromMd(text, fileName, argv.stylesheet);
             await fs.writeFile(htmlPath, html);
         }else{
             throw new Error("Incorrect path");

--- a/src/txt2html.js
+++ b/src/txt2html.js
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
-import marked from "marked";
+
 import {generateFromText, generateFromMd} from "./generator.js";
 
 const argv = yargs(process.argv.slice(2))
@@ -43,7 +43,7 @@ async function txt2html(filePath) {
             const text = (await fs.readFile(filePath)).toString();
             const fileName = path.basename(filePath, path.extname(filePath));
             const htmlPath = path.join(argv.output, fileName + ".html");
-            const html = generateFromMd(mark(text), fileName, argv.stylesheet);
+            const html = generateFromMd(text, fileName, argv.stylesheet);
             await fs.writeFile(htmlPath, html);
         }else{
             throw new Error("Incorrect path");

--- a/src/txt2html.js
+++ b/src/txt2html.js
@@ -1,7 +1,8 @@
 import fs from "fs/promises";
 import path from "path";
 import yargs from "yargs";
-import { generateFromText } from "./generator.js";
+import marked from "marked";
+import {generateFromText} from "./generator.js";
 
 const argv = yargs(process.argv.slice(2))
     .usage("Usage: $0 [options]")
@@ -32,14 +33,20 @@ const argv = yargs(process.argv.slice(2))
 
 async function txt2html(filePath) {
     const fileStat = await fs.stat(filePath);
-    if (fileStat.isFile() && path.extname(filePath) == ".txt") {
+    if (fileStat.isFile() && path.extname(filePath) == ".txt"){
         const text = (await fs.readFile(filePath)).toString();
         const fileName = path.basename(filePath, path.extname(filePath));
         const htmlPath = path.join(argv.output, fileName + ".html");
         const html = generateFromText(text, fileName, argv.stylesheet);
         await fs.writeFile(htmlPath, html);
-    } else {
-        throw new Error("Incorrect path");
+    } else if (fileStat.isFile() && path.extname(filePath) == ".md") {
+            const text = (await fs.readFile(filePath)).toString();
+            const fileName = path.basename(filePath, path.extname(filePath));
+            const htmlPath = path.join(argv.output, fileName + ".html");
+            const html = generateFromText(marked(text), fileName, argv.stylesheet);
+            await fs.writeFile(htmlPath, html);
+        }else{
+            throw new Error("Incorrect path");
     }
 }
 


### PR DESCRIPTION
I updated some code to handle support feature for Markdown page input.
1/ In txt2html.js, I create an else-if in txt2html function to process the .md file. It will pass the text of .md file to an imported function generateFromMd() for converting purpose.
2/In generator.js, I create a function named generateFromMd() to convert .md file into .html file. This process uses 'marked' imported from the library. Also, I add a boldText() function to convert all heading 1 into tag h1 in html.
Basically, I haven't changed any code structure in your previous code. Please review my pull request carefully. Thank you!